### PR TITLE
增加“真机飞行固件刷写”提示

### DIFF
--- a/开发者手册 - 安装及编译.md
+++ b/开发者手册 - 安装及编译.md
@@ -97,3 +97,28 @@
      - `compile_all.sh`默认编译项目中所有代码，因此编译时**请确认每个模块都没有报错**
      - `compile_control.sh`则只编译控制部分代码，若只需要使用控制部分代码，运行`./compile_control.sh`即可，其他编译脚本其自行查阅理解
 
+## 真机飞行需进行飞控固件刷写
+- 如果要使用真机进行试飞，则需要为飞控刷写阿木实验室的Prometheus项目专用的PX4仓库：[Firmware_v110](https://github.com/amov-lab/Firmware_v110)，安装方法如下
+     ```
+     git clone https://github.com/amov-lab/Firmware_v110
+     cd Firmware_v110
+     git submodule update --init --recursive
+     make px4fmu-v5_default 
+     make px4fmu-v5_default upload
+     ```
+     - 刷写-v5是因为P200原装飞控为pixhawk 4 . 如果使用其他pixhawk飞控硬件请参照下表：  
+       Pixhawk 1: px4fmu-v2 default  
+       Pixhawk 1 (2M flash): px4fmu-v3 default      
+       Pixracer: px4fmu-v4 default    
+       Pixhawk 3 Pro: px4fmu-v4pro default  
+       Pixhawk Mini: px4fmu-v3 default  
+       Pixhawk 2: px4fmu-v3 default  
+       mRo Pixhawk: px4fmu-v3 default  
+    - 若使用官方PX4仓库，Prometheus部分功能会失效，需要修改后方能使用（暂无详细说明，需自行解决）
+    - github下载缓慢，加速方法：https://blog.csdn.net/qq_44621510/article/details/95251993
+    
+    
+     
+       
+       
+


### PR DESCRIPTION
gazebo安装配置教程中有说明prometheus需要使用v1.10 ，这是非常重要的信息，不需要gazebo的开发者很可能看不到，而造成很多麻烦。
这里补充了固件刷写教程。